### PR TITLE
feat: いいね機能の追加 #38

### DIFF
--- a/components/Post.vue
+++ b/components/Post.vue
@@ -12,8 +12,8 @@
       <img :src="post.image" alt="">
     </div>
     <div class="actions my-2 ml-4 flex">
-      <img v-if="beLiked" src='/images/heart_active.svg' class="w-6 mr-3">
-      <img v-else src='/images/heart.svg' class="w-6 mr-3">
+      <img v-if="beLiked" src='/images/heart_active.svg' @click="unlike" class="w-6 mr-3">
+      <img v-else src='/images/heart.svg' @click="like" class="w-6 mr-3">
       <p>0</p>
     </div>
     <div class="message mx-4 text-sm">
@@ -23,6 +23,8 @@
 </template>
 
 <script>
+import { db } from '~/plugins/firebase'
+
 export default {
   props: ['post'],
   data () {
@@ -32,6 +34,24 @@ export default {
         photoURL: '/images/post1.jpg'
       },
       beLiked: false
+    }
+  },
+  mounted () {
+    this.likeRef = db.collection('posts').doc(this.post.id).collection('likes')
+    this.checkLikeStatus()
+  },
+  methods: {
+    async like () {
+      await this.likeRef.doc(this.currentUser.uid).set({ uid: this.currentUser.uid})
+      this.beLiked = true
+    },
+    async unlike () {
+      await this.likeRef.doc(this.currentUser.uid).delete()
+      this.beLiked = false
+    },
+    async checkLikeStatus () {
+      const doc = await this.likeRef.doc(this.currentUser.uid).get()
+      this.beLiked = doc.exists
     }
   },
   computed: {


### PR DESCRIPTION
## なにをしたのか
- いいねする / 外す機能を追加
    - postsのドキュメントの下にlikesコレクションを追加し、ログインしているユーザーのIDも指定する
<img width="1440" alt="スクリーンショット 2020-07-18 2 33 27" src="https://user-images.githubusercontent.com/58762157/87819988-3061d400-c8a8-11ea-92ff-e22e0b976692.png">

- Likeメソッド => いいねする
- checkLikeStatus => いいね外す

## 検証結果
- firebase側
    - いいねする
        - likesコレクションが追加され、userIDドキュメントも入ってくる
    - いいね外す
        - likesコレクションがdeleteされる