### PR TITLE
feat: ユーザー情報保存 #44

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -7,7 +7,7 @@
 
 <script>
 import AppFooter from '~/components/Footer.vue'
-import { firebase } from '~/plugins/firebase'
+import { firebase,db } from '~/plugins/firebase'
 import { mapActions } from 'vuex'
 
 export default {
@@ -21,6 +21,11 @@ export default {
     firebase.auth().onAuthStateChanged((user) => {
       if (user) {
         this.setUser(user)
+        db.collection('users').doc(user.uid).set({
+          uid: user.uid,
+          displayName: user.displayName,
+          photoURL: user.photoURL
+        })
       }
     })
   },


### PR DESCRIPTION
## なにをしたのか
- ユーザー情報を保存する為に、ログインした時にfirestoreにusersコレクションを追加する
- userコレクションのドキュメント
    - displayName
    - photoURL
    - uid