### PR TITLE
 全投稿表示するコンポーネント作成 

### DIFF
--- a/components/Footer.vue
+++ b/components/Footer.vue
@@ -8,7 +8,7 @@
       <nuxt-link to="/"><img src="/images/home.svg" class="h-6 my-3"></nuxt-link>
     </div>
     <div v-if="isAuthenticated" class="nav-item w-1/5 flex justify-center">
-      <nuxt-link to="/users"><img src="/images/search (3).svg" class="h-6 my-3"></nuxt-link>
+      <nuxt-link to="/allPosts"><img src="/images/search (3).svg" class="h-6 my-3"></nuxt-link>
     </div>
     <div v-if="isAuthenticated" class="nav-item w-1/5 flex justify-center">
       <img src="/images/follow.svg" class="h-6 my-3" @click="postModal">

--- a/pages/allPosts.vue
+++ b/pages/allPosts.vue
@@ -1,0 +1,33 @@
+<template>
+  <div>
+    <div class="posts overflow-scroll z-0 mb-24">
+    <post v-for="(post, index) in posts" :key="index" :post="post" />
+  </div>
+  </div>
+</template>
+
+<script>
+import Post from '~/components/Post.vue'
+import { db, firebase } from '~/plugins/firebase'
+
+export default {
+  components: {
+    Post
+  },
+  data () {
+    return {
+      posts: []
+    }
+  },
+  mounted () {
+    db.collection('posts').orderBy('createdAt').onSnapshot((snapshot) => {
+      snapshot.docChanges().forEach((change) => {
+        const doc = change.doc
+        if (change.type === 'added') {
+          this.posts.unshift({ id: doc.id, ...doc.data() })
+        }
+      })
+    })
+  }
+}
+</script>


### PR DESCRIPTION
## 関連ISSUE
#54 

## このPRで達成したいこと
- 全ユーザーの投稿を表示するコンポーネントの作成

## 具体的な変更点
- 全ユーザーの投稿表示するコンポーネント追加 => allPosts.vue
- footerのサーチマークにallPostsのリンク追加

## 検証結果
- 全部の投稿が新しいのが上で表示されている

## 今後実現したいこと
- UIを変えて、３列づつの画像のみ表示にして、画像clickすると投稿詳細がみれるようにしたい。
#70 
    - なのでまずは投稿詳細作る
