### PR TITLE
ゲトトアカウントの情報保存

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.tabSize": 2
+}

--- a/components/Post.vue
+++ b/components/Post.vue
@@ -8,7 +8,7 @@
       </div>
       <div class="user-name leading-loose text-sm">
         <nuxt-link :to="`/users/${user.id}`">
-          <p class="font-bold">{{ username }}</p>
+          <p class="font-bold">{{ user.displayName }}</p>
        </nuxt-link>
       </div>
     </div>
@@ -75,9 +75,6 @@ export default {
   computed: {
     currentUser () {
       return this.$store.state.user
-    },
-    username () {
-      return this.user.displayName.charAt(0).toUpperCase() + this.user.displayName.slice(1)
     },
     isProfileMode () {
       return this.mode === 'profile'

--- a/components/Posts.vue
+++ b/components/Posts.vue
@@ -12,9 +12,9 @@
         <div>
           <ul>
             <li>メールアドレス</li>
-            <li><input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-1 px-4 block w-64 appearance-none leading-normal" type="email" v-model="email"/></li>
+            <li><input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-1 px-4 block w-64 appearance-none leading-normal" type="email" v-model="email" /></li>
             <li>パスワード</li>
-            <li><input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-1 px-4 block w-64 appearance-none leading-normal" type="password" v-model="password"/></li>
+            <li><input class="bg-white focus:outline-none focus:shadow-outline border border-gray-300 rounded-lg py-1 px-4 block w-64 appearance-none leading-normal" type="password" v-model="password" /></li>
           </ul>
         </div>
       </div>
@@ -37,8 +37,6 @@
 import Post from '~/components/Post.vue'
 import { db, firebase } from '~/plugins/firebase'
 import { mapActions } from 'vuex'
-import { throttle } from 'throttle-debounce'
-
 
 export default {
   components: {
@@ -47,8 +45,8 @@ export default {
   data () {
     return {
       posts: [],
-      email: 'guests@example.com',
-      password: '7777777',
+      email: 'example@google.com',
+      password: '333333373',
       modalVisible: false
     }
   },

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -6,7 +6,7 @@
 </template>
 
 <script>
-import AppFooter from '~/components/Footer.vue'
+import AppFooter from '~/components/Footer'
 import { firebase,db } from '~/plugins/firebase'
 import { mapActions } from 'vuex'
 
@@ -21,6 +21,11 @@ export default {
     firebase.auth().onAuthStateChanged((user) => {
       if (user) {
         this.setUser(user)
+        if (user.displayName === null || user.photoURL === null) {
+          user.displayName = 'guests'
+          user.photoURL = '/images/icon(2).png'
+          this.setUser(user)
+        }
         db.collection('users').doc(user.uid).set({
           uid: user.uid,
           displayName: user.displayName,

--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -3,9 +3,9 @@
    <div class="user flex justify-between px-8 my-8">
      <div class="flex">
        <div class="user-avatar mr-4">
-         <img :src="user.photoURL" v-if="nullIcon" class="w-12 h-12 rounded-full">
+         <img :src="user.photoURL" class="w-12 h-12 rounded-full">
        </div>
-       <div class="user-name vertical-middle" v-if="nullName">
+       <div class="user-name vertical-middle">
          <p>{{ user.displayName }}</p>
        </div>
      </div>
@@ -81,16 +81,6 @@ export default {
     isCurrentUser () {
       if (this.currentUser) {
         return this.currentUser.uid == this.$route.params.id
-      }
-    },
-    nullIcon () {
-      if (this.user.photoURL == null) {
-        return this.user.photoURL = '/images/icon(2).png'
-      }
-    },
-    nullName () {
-      if (this.user.displayName == null) {
-        return this.user.displayName = 'guests'
       }
     }
   },

--- a/store/index.js
+++ b/store/index.js
@@ -1,7 +1,7 @@
 export const strict = false
 
 export const state = () => {
-  return{
+  return {
     user: null
   }
 }


### PR DESCRIPTION
## 関連ISSUE
#60 

## このPRで達成したいこと
- ゲストアカウントのユーザー情報が保存されるようにする

## 具体的な変更点
- Post.vueで一時的にマイページにdisplayNameとphotoURLが表示されるように対処していたメソッドの削除
- firestoreのusersコレクションに保存する際、displayNameとphotoURLがnullであればゲスト用のdisplayNameとphotoURLを入れて保存してあげる