### PR TITLE
fix: tailwindcssの設定変更

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,13 @@
 ** Default: https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js
 */
 　module.exports = {
+  purge: [
+    "./pages/**/*.vue", 
+    "./components/**/*.vue", 
+    "./plugins/**/*.vue",
+    "./static/**/*.vue",
+    "./store/**/*.vue"
+  ],
   theme: {},
   variants: {},
   plugins: []


### PR DESCRIPTION
## このPRで実現したいこと
- build時にwarning:
Tailwind is not purging unused styles because no template paths have been provided.
がでるのでそれを改善する

## 実際の変更点
- tailwind.config.jsにvueファイルを読み込むようにした