### PR TITLE
docs: purgeにlayout追加

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,15 @@
 ** Docs: https://tailwindcss.com/docs/configuration
 ** Default: https://github.com/tailwindcss/tailwindcss/blob/master/stubs/defaultConfig.stub.js
 */
-　module.exports = {
+module.exports = {
+  purge: [
+    "./pages/**/*.vue", 
+    "./components/**/*.vue", 
+    "./plugins/**/*.vue",
+    "./static/**/*.vue",
+    "./store/**/*.vue",
+    "./layouts/**/*.vue"
+  ],
   theme: {},
   variants: {},
   plugins: []


### PR DESCRIPTION
## このPRで実現したいこと
```
Tailwind is not purging unused styles because no template paths have been provided.
f you have manually configured PurgeCSS outside of Tailwind or are deliberately not
removing unused styles, set `purge: false`
```
このエラー消す

## 具体的な変更点
- tailwind.config.jsに任意のスタイルを名前で参照するプロジェクト内のすべてのファイルを含めた
