### PR TITLE
デプロイ時のfirebaseのerror修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -63,8 +63,16 @@ export default {
     /*
     ** You can extend webpack config here
     */
-    extend (config, ctx) {
+   extend ( config, { isDev, isClient, isServer } ) {
+    if ( isServer ) {
+      config.externals = {
+        '@firebase/app': 'commonjs @firebase/app',
+        '@firebase/firestore': 'commonjs @firebase/firestore',
+        '@firebase/storage': 'commonjs @firebase/storage',
+        '@firebase/auth': 'commonjs @firebase/auth',
+      }
     }
+  }
   },
   env: {
     GNAVI_API_KEY,


### PR DESCRIPTION
## なにをしたのか
- デプロイするとNuxt.js Internal Server Errorがでる。
Vercelが内部的にLambdaを使用していて、LambdaとFirebaseは相性が悪いことが原因らしいので
nuxt.config.jsに記述を追加した