### PR TITLE
マイページにfollow/followerを表示

### DIFF
--- a/components/Follower.vue
+++ b/components/Follower.vue
@@ -1,0 +1,30 @@
+<template>
+  <div class="user p-4 flex justify-between">
+    <div v-for="(follower, index) in followers" :key="index" :follower="follower">
+      <div class="user-info flex">
+        <div class="avatar mr-4">
+            <img :src="follower.photoURL" class="w-12 h-12 rounded-full">
+        </div>
+        <div class="displayName vertical-middle">
+          <p>{{ follower.displayName }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { db } from '~/plugins/firebase'
+
+  export default {
+    data () {
+      return {
+        follower: null
+      }
+    },
+    props: {
+      followers: {}
+    }
+  }
+
+</script>

--- a/components/Following.vue
+++ b/components/Following.vue
@@ -1,0 +1,39 @@
+<template>
+  <div class="user p-4 flex justify-between">
+    <div v-for="(followingUser, index) in followingUsers" :key="index" :followingUser="followingUser">
+      <div class="user-info flex">
+        <div class="avatar mr-4">
+            <img :src="followingUser.photoURL" class="w-12 h-12 rounded-full">
+        </div>
+        <div class="displayName vertical-middle">
+          <p>{{ followingUser.displayName }}</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import { db } from '~/plugins/firebase'
+
+  export default {
+    data () {
+      return {
+        followingUser: null,
+        followingUsers: []
+      }
+    },
+    computed: {
+      currentUser () {
+        return this.$store.state.user
+      }
+    },
+    async mounted () {
+      const snapshot = await db.collection('users').doc(this.currentUser.uid).collection('followings').get()
+      snapshot.forEach((doc) => {
+        this.followingUsers.push(doc.data())
+      })
+    }
+  }
+
+</script>

--- a/components/User.vue
+++ b/components/User.vue
@@ -45,10 +45,18 @@ import { db } from '~/plugins/firebase'
     },
     methods: {
       async follow () {
-        await this.followingRef.set({user: this.user.id})
-        await this.followerRef.set({ user: this.currentUser.uid})
+        await this.followingRef.set({
+          user: this.user.id,
+          photoURL: this.user.photoURL,
+          displayName: this.user.displayName
+          })
+        await this.followerRef.set({ 
+          user: this.currentUser.uid,
+          photoURL: this.currentUser.photoURL,
+          displayName: this.currentUser.displayName
+          })
         this.followed = true
-     },
+      },
       async unfollow () {
         await this.followingRef.delete()
         await  this.followerRef.delete()

--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -13,23 +13,26 @@
    </div>
    <div class="tab flex justify-around">
      <div class="post-count text-center">
-       Post
-       </br>
+       <p @click="mode = modes.posts">Post</p>
        <span class="text-xs">{{ posts.length }}</span>
      </div>
      <div class="text-center">
-       <nuxt-link to="/users">Following</nuxt-link>
-       </br>
+       <p @click="mode = modes.followings">Following</p>
        <span class="text-xs">{{ followingCount }}</span>
      </div>
      <div class="text-center">
-       Follower
-       </br>
+       <p @click="mode = modes.follower">Follower</p>
        <span class="text-xs">{{ followerCount }}</span>
      </div>
    </div>
-   <div class="foo">
-   <post v-for="post in posts" :key="post.id" :post="post" :mode="'profile'"/>
+   <div class="post" v-if="mode === modes.posts">
+    <post v-for="post in posts" :key="post.id" :post="post" :mode="'profile'"/>
+   </div>
+   <div v-else-if="mode === modes.followings">
+     <following />
+   </div>
+   <div v-else-if="mode === modes.follower">
+     <follower :followers="followers" />
    </div>
  </div>
 </template>
@@ -38,10 +41,15 @@
 import { firebase,db } from '~/plugins/firebase'
 import { mapActions } from 'vuex'
 import Post from '~/components/Post'
+import Following from '~/components/Following'
+import Follower from '~/components/Follower'
+
 
 export default {
   components: {
-    Post
+    Post,
+    Following,
+    Follower
   },
   data () {
     return {
@@ -51,7 +59,14 @@ export default {
         displayName: '',
         photoURL: ''
       },
-      posts: []
+      posts: [],
+      modes: {
+        posts: 'posts',
+        followings: 'followings',
+        followers: 'followers'
+      },
+      mode: 'posts',
+      followers: []
     }
   },
   methods: {
@@ -99,12 +114,18 @@ export default {
     this.fetchFollowingCount()
     this.fetchFollowerCount()
 
+    const userID = this.$route.params.id
+    const snap = await db.collection('users').doc(userID).collection('followers').get()
+    snap.forEach((doc) => {
+      this.followers.push(doc.data())
+    })
+
   }
 }
 </script>
 
 <style scoped>
-.foo{
+.post{
   box-sizing: border-box;
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## 関連ISSUE
#100 

## このPRで実現したいこと
- follower と following を分けてマイページに表示する

## 具体的な変更点
- followerコンポーネントとfollowingコンポーネントを分けてuser/_idコンポーネントにおいた