### PR TITLE
fix: 投稿詳細モーダルでコメントが反映されないのを改善 #135

### DIFF
--- a/components/Post.vue
+++ b/components/Post.vue
@@ -110,11 +110,13 @@ export default {
       })
     },
     async setComment () {
+      let time = new Date().getTime()
+
       await this.commentRef.add({
         comment: this.postComment,
         userName: this.currentUser.displayName,
         userId: this.currentUser.uid,
-        createdAt: new Date().getTime()
+        createdAt: time + ''
       })
       this.postComment = null
     },

--- a/components/PostDetails.vue
+++ b/components/PostDetails.vue
@@ -91,16 +91,18 @@ export default {
       this.beLiked = false
     },
     async setComment () {
+      let time = new Date().getTime()
+
       await this.commentRef.add({
         comment: this.postComment,
         userName: this.currentUser.displayName,
         userId: this.currentUser.uid,
-        createdAt: new Date().getTime()
+        createdAt: time + ''
       })
       this.postComment = null
     },
     async checkComment () {
-      await this.commentRef.orderBy('createdt').onSnapshot((snapshot) => {
+      await this.commentRef.orderBy('createdAt').onSnapshot((snapshot) => {
         snapshot.docChanges().forEach((change) => {
           const doc = change.doc
           this.comments.push(doc.data())


### PR DESCRIPTION
## 関連ISSUE
#135 

## このPRで実現したいこと
- 投稿を詳細モーダルでみたときにコメントしても反映されないのを改善する。
反映されるようにする。

## 具体的な変更点
- createdAtを文字列に変更
- createdtってタイポミスしていたので修正

