### PR TITLE
docs: ログアウト時のページ推移先変更

### DIFF
--- a/pages/users/_id.vue
+++ b/pages/users/_id.vue
@@ -87,7 +87,7 @@ export default {
       firebase.auth().signOut()
         .then(() => {
           this.setUser(null)
-          location.href = "http://localhost:3000/"
+          location.href = "/"
         })
         .catch((error) => {
           window.alert(error)


### PR DESCRIPTION
## 関連ISSUE
#106 

## 関連PR
#140 

## 具体的な変更点
- ログアウト時のページ推移先が本番環境に対応していないものだったため
パスで指定しなおした。