### PR TITLE
bug: serialize-javascriptのversion変更 #154

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2301,7 +2301,7 @@
                 "find-cache-dir": "^2.1.0",
                 "is-wsl": "^1.1.0",
                 "schema-utils": "^1.0.0",
-                "serialize-javascript": "^3.1.0",
+                "serialize-javascript": ">=3.1.0",
                 "source-map": "^0.6.1",
                 "terser": "^4.1.2",
                 "webpack-sources": "^1.4.0",


### PR DESCRIPTION
## 関連ISSUE 
#154 

## このPRで実現したいこと
- Githubからセキュリティ脆弱性に関する勧告が来ているのでその改善
<img width="956" alt="スクリーンショット 2020-08-17 17 57 44" src="https://user-images.githubusercontent.com/58762157/90379465-bf375b80-e0b5-11ea-9465-117983c5690b.png">


## 具体的な変更点
packege-lock.jsonのserialize-javascriptを>=3.1.0に変更した